### PR TITLE
App extension flag

### DIFF
--- a/Files/WAAppRouteHandler.m
+++ b/Files/WAAppRouteHandler.m
@@ -272,6 +272,14 @@
 
 #pragma mark - View controller management
 
+- (UIViewController *)rootViewController {
+#ifndef WA_APP_EXTENSION
+  return [[[UIApplication sharedApplication] keyWindow] rootViewController];
+#endif
+  
+  return nil;
+}
+
 // Present the controller and deal with where it should be
 - (UIViewController *)presentTargetViewControllerClass:(Class)targetViewControllerClass
                   inNavigationControllerViewController:(UINavigationController *)navigationController
@@ -290,7 +298,7 @@
         // Get the controller which will act as the presentation controller
         UIViewController *presentingViewController = navigationController;
         if (!presentingViewController) {
-            presentingViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+          presentingViewController = [self rootViewController];
         }
         // Present
         [presentingViewController presentViewController:navController animated:animated completion:NULL];

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ So you might recognize some concept of the two libraries especially in the route
 ## Installation
 Use Cocoapods, this is the easiest way to install the router.
 
+If you want to link `WAAppRouting` into an iOS app extension (or a shared framework that is linked to an app extension), you'll need to ensure that the `WA_APP_EXTENSION` flag is set when you compile the framework.  To do so using Cocoapods, add this to your `Podfile`:
+
+```ruby
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    if target.name =~ /WAAppRouting/
+      target.build_configurations.each do |config|
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= []
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'WA_APP_EXTENSION=1'
+      end
+    end
+  end
+end
+```
+
+Older versions of cocoapods may require you to use `installer.project` instead of `installer.pods_project`, so if you get an error complaining that `pods_project` does not exist, update your cocoapods gem.
+
 Then, well import `#import <WAAppRouting/WAAppRouting.h>` and you are good to go.
 
 You also need to configure a URL scheme (I won't get back to this, there is plenty of documentation out there)


### PR DESCRIPTION
@ipodishima here's a much simpler app-extension compatibility PR that uses a `WA_APP_EXTENSION` flag to avoid calling `[UIApplication sharedApplication]`.

Thanks for the sweet library, btw.  Not being able to define a stack of view controllers was my main frustration with existing routing libs also.  You saved me from having to write all this from scratch :)
