### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ So you might recognize some concepts of the two libraries, especially in the rou
 - The route matching works on `:itemID` and uses `*` as the wildcard character.
 
 ## Installation
-### Cocoapods
-Use Cocoapods, this is the easiest way to install the router.
+### CocoaPods
+Use CocoaPods, this is the easiest way to install the router.
 
 `pod 'WAAppRouting'`
 
-If you want to link `WAAppRouting` into an iOS app extension (or a shared framework that is linked to an app extension), you'll need to ensure that the `WA_APP_EXTENSION` flag is set when you compile the framework.  To do so using Cocoapods, add this to your `Podfile`:
+If you want to link `WAAppRouting` into an iOS app extension (or a shared framework that is linked to an app extension), you'll need to ensure that the `WA_APP_EXTENSION` flag is set when you compile the framework.  To do so using CocoaPods, add this to your `Podfile`:
 
 ```ruby
 post_install do |installer|


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
